### PR TITLE
fix: Various errors working with `file` protocol

### DIFF
--- a/tap_text_anywhere/streams.py
+++ b/tap_text_anywhere/streams.py
@@ -75,13 +75,15 @@ class TextStream(text_anywhereStream):
             ):
                 continue
             empty = False
+
+            filename = file["name"].split("/")[-1]
+
             if self.config["protocol"] == "s3":
                 if file["LastModified"].isoformat() < self.config["start_date"] or file[
                     "LastModified"
                 ].isoformat() <= self.get_starting_replication_key_value(context):
                     continue
 
-                filename = file["name"].split("/")[-1]
                 tmpfile = tempfile.NamedTemporaryFile(
                     suffix=filename,
                     delete=False,

--- a/tap_text_anywhere/streams.py
+++ b/tap_text_anywhere/streams.py
@@ -78,6 +78,9 @@ class TextStream(text_anywhereStream):
 
             filename = file["name"].split("/")[-1]
 
+            last_modified = file.get("LastModified")
+            updated_at = last_modified and last_modified.iso_format()
+
             if self.config["protocol"] == "s3":
                 if file["LastModified"].isoformat() < self.config["start_date"] or file[
                     "LastModified"
@@ -97,7 +100,7 @@ class TextStream(text_anywhereStream):
                     yield {
                         "filename": filename,
                         "textcontent": chunk.page_content,
-                        "updated_at": file["LastModified"].isoformat(),
+                        "updated_at": updated_at,
                         "hash": md5(chunk.page_content.encode("utf-8")).hexdigest(),
                     }
 
@@ -108,7 +111,7 @@ class TextStream(text_anywhereStream):
                     yield {
                         "filename": filename,
                         "textcontent": chunk.page_content,
-                        "updated_at": file["LastModified"].isoformat(),
+                        "updated_at": updated_at,
                         "hash": md5(chunk.page_content.encode("utf-8")).hexdigest(),
                     }
             else:

--- a/tap_text_anywhere/tap.py
+++ b/tap_text_anywhere/tap.py
@@ -95,7 +95,7 @@ class Tap_text_anywhere(Tap):
         th.Property(
             "chunk_size",
             th.IntegerType,
-            default="once",
+            default=1000,
             description=("Size of text chunks to make up a record."),
         ),
         th.Property(


### PR DESCRIPTION
A note on `KeyError: 'LastModified'`: I'm assuming I encountered this error because I'm on a Unix-like OS (Ubuntu) and not Windows? I couldn't find a suitable replacement, so just indicate `null` for `updated_at` if it can't find a `LastModified` value.